### PR TITLE
Add mental health webhook agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # Experiment
+
+This project demonstrates a minimal AI powered mental health agent.
+
+## Features
+
+- **Webhook API**: A Flask server exposes `/webhook` for POST requests. The
+  payload must include a `message` field.
+- **Trait Detection**: `MentalHealthAgent` performs a simple keyword based scan
+  of the message to infer potential mental health traits such as anxiety,
+  depression or stress.
+- **Suggestions**: Based on detected traits, the agent responds with basic
+  wellbeing suggestions.
+- **Notion Integration**: If `NOTION_API_TOKEN` and `NOTION_PARENT_PAGE_ID` are
+  provided as environment variables, incoming messages and generated
+  suggestions are stored as a page in Notion.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export your Notion token and parent page ID if you want Notion integration:
+   ```bash
+   export NOTION_API_TOKEN="secret_xxx"
+   export NOTION_PARENT_PAGE_ID="your_page_id"
+   ```
+3. Run the server:
+   ```bash
+   python app.py
+   ```
+
+Send a POST request to `http://localhost:5000/webhook` with JSON body
+`{"message": "I feel very stressed about my work"}` to see the response.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+from flask import Flask, request, jsonify
+from mental_health_agent import MentalHealthAgent
+import notion_client_util as notion_util
+import os
+
+app = Flask(__name__)
+agent = MentalHealthAgent()
+
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    data = request.get_json(force=True)
+    if not data or 'message' not in data:
+        return jsonify({'error': 'message field required'}), 400
+
+    message = data['message']
+    traits = agent.detect_traits(message)
+    suggestions = agent.get_suggestions(traits)
+
+    # optionally create a page in Notion
+    parent_page_id = os.environ.get('NOTION_PARENT_PAGE_ID')
+    notion_response = None
+    if parent_page_id:
+        try:
+            notion_response = notion_util.create_page(
+                title='Mental Health Entry',
+                content=(
+                    message
+                    + '\n\nSuggestions:\n'
+                    + '\n'.join(suggestions)
+                ),
+                parent_page_id=parent_page_id,
+            )
+        except Exception as e:
+            notion_response = {'error': str(e)}
+
+    return jsonify({
+        'traits': traits,
+        'suggestions': suggestions,
+        'notion': notion_response,
+    })
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))

--- a/mental_health_agent.py
+++ b/mental_health_agent.py
@@ -1,0 +1,44 @@
+class MentalHealthAgent:
+    """Basic rule-based detector and suggestion generator."""
+
+    def __init__(self):
+        # keywords representing mental health traits
+        self.traits_keywords = {
+            "anxiety": ["anxious", "nervous", "worry", "panic"],
+            "depression": ["sad", "down", "hopeless", "tired"],
+            "stress": ["stress", "overwhelmed", "pressure", "burnout"],
+        }
+        self.suggestions = {
+            "anxiety": (
+                "Try deep breathing exercises or mindfulness meditation."
+            ),
+            "depression": (
+                "Consider talking to a trusted friend or professional "
+                "therapist."
+            ),
+            "stress": (
+                "Take short breaks during work and practice relaxation "
+                "techniques."
+            ),
+        }
+
+    def detect_traits(self, text: str):
+        traits = []
+        text_lower = text.lower()
+        for trait, keywords in self.traits_keywords.items():
+            for kw in keywords:
+                if kw in text_lower:
+                    traits.append(trait)
+                    break
+        return traits
+
+    def get_suggestions(self, traits):
+        if not traits:
+            return [
+                "Keep monitoring your mental well-being and stay positive!"
+            ]
+        return [
+            self.suggestions[trait]
+            for trait in traits
+            if trait in self.suggestions
+        ]

--- a/notion_client_util.py
+++ b/notion_client_util.py
@@ -1,0 +1,33 @@
+import os
+from notion_client import Client
+
+
+def get_notion_client():
+    token = os.environ.get("NOTION_API_TOKEN")
+    if not token:
+        raise ValueError("NOTION_API_TOKEN environment variable is required")
+    return Client(auth=token)
+
+
+def create_page(title: str, content: str, parent_page_id: str):
+    """Create a simple Notion page under given parent."""
+    notion = get_notion_client()
+    return notion.pages.create(
+        parent={"page_id": parent_page_id},
+        properties={
+            "title": [
+                {
+                    "text": {"content": title}
+                }
+            ]
+        },
+        children=[
+            {
+                "object": "block",
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [{"text": {"content": content}}]
+                },
+            }
+        ],
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.1.1
+notion-client==2.3.0
+


### PR DESCRIPTION
## Summary
- implement minimal `MentalHealthAgent` for keyword-based trait detection
- add Notion integration utility
- expose `/webhook` endpoint using Flask
- document setup and usage in README
- provide dependency list

## Testing
- `flake8 .`
- `curl -X POST -H 'Content-Type: application/json' -d '{"message":"I am feeling anxious and stressed"}' http://127.0.0.1:5000/webhook`

------
https://chatgpt.com/codex/tasks/task_e_684007c05d74832298566f1d86c2137e